### PR TITLE
Android watchers added

### DIFF
--- a/src/main/kotlin/es/babel/cdm/utils/android/watcher/AfterTextChangedWatcher.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/android/watcher/AfterTextChangedWatcher.kt
@@ -1,0 +1,19 @@
+package es.babel.cdm.utils.android.watcher
+
+import android.text.Editable
+import android.text.TextWatcher
+
+class AfterTextChangedWatcher(private val afterTextChanged: (s: Editable?) -> Unit) : TextWatcher {
+
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+        // Nothing to do
+    }
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+        // Nothing to do
+    }
+
+    override fun afterTextChanged(s: Editable?) {
+        afterTextChanged.invoke(s)
+    }
+}

--- a/src/main/kotlin/es/babel/cdm/utils/android/watcher/OnSpanChangedWatcher.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/android/watcher/OnSpanChangedWatcher.kt
@@ -1,0 +1,34 @@
+package es.babel.cdm.utils.android.watcher
+
+import android.text.SpanWatcher
+import android.text.Spannable
+
+class OnSpanChangedWatcher(
+    private val onSpanChanged: (
+        text: Spannable?,
+        what: Any?,
+        oStart: Int,
+        oEnd: Int,
+        nStart: Int,
+        nEnd: Int
+    ) -> Unit
+) : SpanWatcher {
+    override fun onSpanAdded(text: Spannable?, what: Any?, start: Int, end: Int) {
+        // Nothing to do
+    }
+
+    override fun onSpanRemoved(text: Spannable?, what: Any?, start: Int, end: Int) {
+        // Nothing to do
+    }
+
+    override fun onSpanChanged(
+        text: Spannable?,
+        what: Any?,
+        oStart: Int,
+        oEnd: Int,
+        nStart: Int,
+        nEnd: Int
+    ) {
+        onSpanChanged.invoke(text, what, oStart, oEnd, nStart, nEnd)
+    }
+}


### PR DESCRIPTION
Why:
    - Cause the applications used to need this kind of watchers.
How:
    - Adding Text and Span watchers.