### PR TITLE
Error handler and remote exception iterceptor added

### DIFF
--- a/src/main/kotlin/es/babel/cdm/utils/net/ErrorHandler.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/net/ErrorHandler.kt
@@ -1,0 +1,7 @@
+package es.babel.cdm.utils.net
+
+import okhttp3.Response
+
+interface ErrorHandler {
+    fun handleError(response: Response): Throwable
+}

--- a/src/main/kotlin/es/babel/cdm/utils/net/interceptor/RemoteExceptionInterceptor.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/net/interceptor/RemoteExceptionInterceptor.kt
@@ -1,0 +1,18 @@
+package es.babel.cdm.utils.net.interceptor
+
+import es.babel.cdm.utils.net.ErrorHandler
+import okhttp3.Interceptor
+
+class RemoteExceptionInterceptor(private val errorHandler: ErrorHandler) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain) =
+        kotlin.runCatching {
+            chain.proceed(chain.request()).also { response ->
+                if (response.code >= MIN_HTTP_ERROR_CODE)
+                    throw errorHandler.handleError(response)
+            }
+        }.getOrThrow()
+
+    companion object {
+        const val MIN_HTTP_ERROR_CODE = 300
+    }
+}


### PR DESCRIPTION
Why:
    - Cause the applications used to need this kind of utils.
How:
    - Adding remote exception interceptor.
    - Adding error handler interface.