### PR TITLE
Validation utils added

### DIFF
--- a/src/main/kotlin/es/babel/cdm/utils/constants/Size.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/constants/Size.kt
@@ -1,0 +1,7 @@
+package es.babel.cdm.utils.constants
+
+object Size {
+    const val NO_SIZE = 0
+    const val NO_WIDTH = 0
+    const val NO_HEIGHT = 0
+}


### PR DESCRIPTION
Why:
    - Cause the applications used to need this kind of utils.
How:
    - Adding size constants.