### PR TITLE
ISO codes constants added

### DIFF
--- a/src/main/kotlin/es/babel/cdm/utils/constants/ISOCode.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/constants/ISOCode.kt
@@ -1,0 +1,6 @@
+package es.babel.cdm.utils.constants
+
+object ISOCode {
+    const val SPAIN = "ES"
+    const val PORTUGAL = "PT"
+}


### PR DESCRIPTION
Why:
    - Cause the applications used to need this kind of constants.
How:
    - Adding a new object.