### PR TITLE
Open Play Store extension

### DIFF
--- a/src/main/kotlin/es/babel/cdm/utils/android/extensions.kt
+++ b/src/main/kotlin/es/babel/cdm/utils/android/extensions.kt
@@ -16,3 +16,21 @@ fun Context.openAppSettings(packageName: String) {
 
     startActivity(intent)
 }
+
+fun Context.openPlayStore(packageName: String) {
+    runCatching {
+        startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("market://details?id=$packageName")
+            )
+        )
+    }.recoverCatching {
+        startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+            )
+        )
+    }
+}


### PR DESCRIPTION
Why:
* Open Play Store with `packageName` specified.

How:
* Tries to open Play Store application.
* If not found, tries to open web browser.
* If no browser is found, then is not possible open anything.
